### PR TITLE
Minor improvements and fixes to #1 

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -335,6 +335,8 @@ Resources:
           else
             export PUBLIC_IP="${InstanceEIP}"
           fi
+          echo "127.0.0.1 $PRIMARY_HOSTNAME" >> /etc/hosts
+
           # Setup Admin Account.
           export EMAIL_ADDR="admin@${MailInABoxDomain}"
           # If no admin password is specified generate a random one. In that case, we upload this randomly genereated PW to SSM if it's a fresh install

--- a/template.yaml
+++ b/template.yaml
@@ -306,9 +306,9 @@ Resources:
             unzip \
             intltool \
             python-is-python3
-          pip3 install duplicity==1.0.1
-          # snap install duplicity --classic
-          # ln -s /snap/bin/duplicity /usr/bin/duplicity
+
+          # Install duplicity via snap
+          snap install duplicity --classic && ln -s /snap/bin/duplicity /usr/local/sbin/
 
           # Install awscli and CloudFormation helper scripts
           cd /tmp
@@ -395,6 +395,8 @@ Resources:
           cd /opt/mailinabox/ && setup/start.sh
 
           # ---------------- POST INSTALL
+          # Get rid of duplicity installed by MIAB
+          apt-get remove -o DPkg::Lock::Timeout=120 -y duplicity && ln -s /snap/bin/duplicity /usr/bin/
           # Configure networking according to https://aws.amazon.com/premiumsupport/knowledge-center/ec2-static-dns-ubuntu-debian/
           INTERFACE=$(ip route list | grep default | grep -E  'dev (\w+)' -o | awk '{print $2}')
           cat <<EOT > /etc/netplan/99-custom-dns.yaml

--- a/template.yaml
+++ b/template.yaml
@@ -173,7 +173,7 @@ Resources:
   InstanceRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: MailInABoxInstanceRole
+      RoleName: !Sub MailInABoxInstanceRole-${AWS::StackName}
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -253,7 +253,7 @@ Resources:
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties: 
-      InstanceProfileName: MailInABoxInstanceProfile
+      InstanceProfileName: !Sub MailInABoxInstanceProfile-${AWS::StackName}
       Roles: 
        - !Ref InstanceRole
 

--- a/template.yaml
+++ b/template.yaml
@@ -30,6 +30,10 @@ Parameters:
     Description: Managed AMI ID for EC2 Instance
     Type : AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
     Default: '/aws/service/canonical/ubuntu/server/jammy/stable/current/amd64/hvm/ebs-gp2/ami-id'
+  InstanceVolumeSize:
+    Description: Size of Instance root volume in GB
+    Type : String
+    Default: 10
   InstanceDns:
     Description: DNS name of Instance (within the 'MailInABoxDomain') 
     Type: String
@@ -279,8 +283,8 @@ Resources:
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
-            VolumeType: gp2
-            VolumeSize: 8
+            VolumeType: gp3
+            VolumeSize: !Ref InstanceVolumeSize
             DeleteOnTermination: true
             Encrypted: true
       Tags:


### PR DESCRIPTION
- Add loopback address for server FQDN to /etc/hosts (#1 )
-  Install duplicity via snap rather than pip
-  Unique resource names to allow co-existance of cloudformation stacks
-  Moving to gp3 and making the root volume size a parameter